### PR TITLE
feat: TR-3-Diego::ABM factura digital y card con detalle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
 
 <body>
   <div id="root"></div>
+  <div id="portal"></div>
 </body>
 
 </html>

--- a/src/app/components/IconTag/index.js
+++ b/src/app/components/IconTag/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CancelIcon from '@material-ui/icons/Cancel';
+
+import { tagTypes } from 'types/tagTypes';
+
+import styles from './styles.module.scss';
+
+const IconTag = ({ tagState }) => (
+  <div className={styles[`subscriptionTag-${tagState.status}`]}>
+    {tagState.status === 'success' ? (
+      <CheckCircleIcon className={styles['icon-success']} />
+    ) : (
+      <CancelIcon className={styles['icon-error']} />
+    )}
+    <span>{tagState.text}</span>
+  </div>
+);
+
+IconTag.propTypes = {
+  tagState: tagTypes
+};
+
+export default IconTag;

--- a/src/app/components/IconTag/styles.module.scss
+++ b/src/app/components/IconTag/styles.module.scss
@@ -1,0 +1,54 @@
+@import 'scss/variables/_fontSizes.scss';
+@import '_colors.scss';
+
+.subscriptionTag {
+  align-items: center;
+  border-radius: 8px;
+  display: flex;
+  font-size: $small;
+  overflow: hidden;
+  padding: 4px 6px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: fit-content;
+
+  &-error {
+    @extend .subscriptionTag;
+    background-color: $primary-variant-3;
+    color: $error;
+
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  &-success {
+    @extend .subscriptionTag;
+    background-color: $primary-text-button-hover;
+    color: $input-primary;
+
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .icon {
+    height: 16px;
+    margin-right: 4px;
+    width: 16px;
+
+    &-error {
+      @extend .icon;
+      color: $error;
+    }
+
+    &-success {
+      @extend .icon;
+      color: $input-primary;
+    }
+  }
+}

--- a/src/app/components/Modal/index.js
+++ b/src/app/components/Modal/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { UTButton } from '@widergy/energy-ui';
+
+import styles from './styles.module.scss';
+
+const Modal = ({
+  actionOnly,
+  cancelOnly,
+  cancelText,
+  children,
+  ctaText,
+  disableCancel = false,
+  disableCta = false,
+  handleCancel,
+  handleCta
+}) =>
+  createPortal(
+    <div className={styles.backdrop}>
+      <div className={styles.modal}>
+        {children}
+        <div className={styles.buttonBox}>
+          {!actionOnly && (
+            <UTButton disabled={disableCancel} classNames={{ root: styles.cancel }} onClick={handleCancel}>
+              {cancelText || 'Cancel'}
+            </UTButton>
+          )}
+          {!cancelOnly && (
+            <UTButton disabled={disableCta} classNames={{ root: styles.cta }} onClick={handleCta}>
+              {ctaText || 'Action'}
+            </UTButton>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.getElementById('portal')
+  );
+
+export default Modal;

--- a/src/app/components/Modal/styles.module.scss
+++ b/src/app/components/Modal/styles.module.scss
@@ -1,0 +1,50 @@
+@import 'scss/variables/_sizes.scss';
+@import 'scss/variables/_fontSizes.scss';
+@import 'scss/variables/_mediaQueries.scss';
+@import '_colors.scss';
+
+.backdrop {
+  background-color: $gray;
+  height: 100%;
+  inset: 0;
+  position: fixed;
+  width: 100%;
+
+  .modal {
+    align-items: center;
+    background-color: $black;
+    border-radius: 8px;
+    color: $white;
+    display: flex;
+    flex-flow: column nowrap;
+    height: fit-content;
+    justify-content: space-between;
+    left: 50%;
+    padding: 24px;
+    position: absolute;
+    top: 50%;
+    translate: -50% -50%;
+    width: fit-content;
+
+    .buttonBox {
+      display: flex;
+      margin-top: 16px;
+      width: fit-content;
+
+      .cancel,
+      .cta {
+        width: 100px;
+      }
+
+      .cancel {
+        background-color: $gray;
+        margin-right: 16px;
+      }
+
+      .cta {
+        background-color: $primary-text-button-hover;
+        color: $black;
+      }
+    }
+  }
+}

--- a/src/app/screens/Home/components/DigitalBilling/index.js
+++ b/src/app/screens/Home/components/DigitalBilling/index.js
@@ -1,0 +1,64 @@
+import React, { Fragment } from 'react';
+import { arrayOf, bool, func, string } from 'prop-types';
+import { UTCard, UTLabel, UTButton } from '@widergy/energy-ui';
+import i18 from 'i18next';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CancelIcon from '@material-ui/icons/Cancel';
+
+import styles from './styles.module.scss';
+
+const DigitalBilling = ({ emails, handleModify, handleSubscribe, handleUnsubscribe, subscription }) => (
+  <UTCard classNames={{ base: styles.digitalBilling }}>
+    <UTLabel className={styles.title}>{i18.t('Home:digitalBilling')}</UTLabel>
+    {subscription ? (
+      <Fragment>
+        <div className={styles['subscriptionTag-success']}>
+          <CheckCircleIcon className={styles['icon-success']} />
+          <span>{i18.t('Home:digitalBillSubscribed')}</span>
+        </div>
+        <ul className={styles.emailList}>
+          <span>Emails asociados:</span>
+          {emails.map(email => (
+            <li key={email}>{email}</li>
+          ))}
+        </ul>
+        <div className={styles.buttonsBox}>
+          <UTButton classNames={{ root: styles['digitalBillingButtons-modify'] }} onClick={handleModify}>
+            {i18.t('Home:digitalBillingModify')}
+          </UTButton>
+          <UTButton
+            classNames={{ root: styles['digitalBillingButtons-unsubscribe'] }}
+            onClick={handleUnsubscribe}
+          >
+            {i18.t('Home:digitalBillingUnsubscribe')}
+          </UTButton>
+        </div>
+      </Fragment>
+    ) : (
+      <Fragment>
+        <div className={styles['subscriptionTag-error']}>
+          <CancelIcon className={styles['icon-error']} />
+          <span>{i18.t('Home:digitalBillNotSubscribed')}</span>
+        </div>
+        <div className={styles.buttonsBox}>
+          <UTButton
+            classNames={{ root: styles['digitalBillingButtons-subscribe'] }}
+            onClick={handleSubscribe}
+          >
+            {i18.t('Home:digitalBillingSubscribe')}
+          </UTButton>
+        </div>
+      </Fragment>
+    )}
+  </UTCard>
+);
+
+DigitalBilling.propTypes = {
+  emails: arrayOf(string),
+  handleModify: func,
+  handleSubscribe: func,
+  handleUnsubscribe: func,
+  subscription: bool
+};
+
+export default DigitalBilling;

--- a/src/app/screens/Home/components/DigitalBilling/index.js
+++ b/src/app/screens/Home/components/DigitalBilling/index.js
@@ -1,55 +1,57 @@
 import React, { Fragment } from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
-import { UTCard, UTLabel, UTButton } from '@widergy/energy-ui';
+import { UTCard, UTLabel, UTButton, UTLoading } from '@widergy/energy-ui';
 import i18 from 'i18next';
-import CheckCircleIcon from '@material-ui/icons/CheckCircle';
-import CancelIcon from '@material-ui/icons/Cancel';
+
+import { tagTypes } from 'types/tagTypes';
+import IconTag from 'app/components/IconTag';
 
 import styles from './styles.module.scss';
 
-const DigitalBilling = ({ emails, handleModify, handleSubscribe, handleUnsubscribe, subscription }) => (
+const DigitalBilling = ({
+  emails,
+  handleModify,
+  handleSubscribe,
+  handleUnsubscribe,
+  loading,
+  subscription,
+  tagState
+}) => (
   <UTCard classNames={{ base: styles.digitalBilling }}>
-    <UTLabel className={styles.title}>{i18.t('Home:digitalBilling')}</UTLabel>
-    {subscription ? (
-      <Fragment>
-        <div className={styles['subscriptionTag-success']}>
-          <CheckCircleIcon className={styles['icon-success']} />
-          <span>{i18.t('Home:digitalBillSubscribed')}</span>
-        </div>
+    <UTLoading loading={loading}>
+      <UTLabel className={styles.title}>{i18.t('digitalBills:digitalBilling')}</UTLabel>
+      <IconTag tagState={tagState} />
+      {subscription && (
         <ul className={styles.emailList}>
           <span>Emails asociados:</span>
           {emails.map(email => (
             <li key={email}>{email}</li>
           ))}
         </ul>
-        <div className={styles.buttonsBox}>
-          <UTButton classNames={{ root: styles['digitalBillingButtons-modify'] }} onClick={handleModify}>
-            {i18.t('Home:digitalBillingModify')}
-          </UTButton>
-          <UTButton
-            classNames={{ root: styles['digitalBillingButtons-unsubscribe'] }}
-            onClick={handleUnsubscribe}
-          >
-            {i18.t('Home:digitalBillingUnsubscribe')}
-          </UTButton>
-        </div>
-      </Fragment>
-    ) : (
-      <Fragment>
-        <div className={styles['subscriptionTag-error']}>
-          <CancelIcon className={styles['icon-error']} />
-          <span>{i18.t('Home:digitalBillNotSubscribed')}</span>
-        </div>
-        <div className={styles.buttonsBox}>
+      )}
+      <div className={styles.buttonsBox}>
+        {subscription ? (
+          <Fragment>
+            <UTButton classNames={{ root: styles['digitalBillingButtons-modify'] }} onClick={handleModify}>
+              {i18.t('digitalBills:digitalBillingModify')}
+            </UTButton>
+            <UTButton
+              classNames={{ root: styles['digitalBillingButtons-unsubscribe'] }}
+              onClick={handleUnsubscribe}
+            >
+              {i18.t('digitalBills:digitalBillingUnsubscribe')}
+            </UTButton>
+          </Fragment>
+        ) : (
           <UTButton
             classNames={{ root: styles['digitalBillingButtons-subscribe'] }}
             onClick={handleSubscribe}
           >
-            {i18.t('Home:digitalBillingSubscribe')}
+            {i18.t('digitalBills:digitalBillingSubscribe')}
           </UTButton>
-        </div>
-      </Fragment>
-    )}
+        )}
+      </div>
+    </UTLoading>
   </UTCard>
 );
 
@@ -58,7 +60,9 @@ DigitalBilling.propTypes = {
   handleModify: func,
   handleSubscribe: func,
   handleUnsubscribe: func,
-  subscription: bool
+  loading: bool,
+  subscription: bool,
+  tagState: tagTypes
 };
 
 export default DigitalBilling;

--- a/src/app/screens/Home/components/DigitalBilling/styles.module.scss
+++ b/src/app/screens/Home/components/DigitalBilling/styles.module.scss
@@ -1,0 +1,141 @@
+@import 'scss/variables/_sizes.scss';
+@import 'scss/variables/_fontSizes.scss';
+@import 'scss/variables/_mediaQueries.scss';
+@import '_colors.scss';
+
+%buttons {
+  height: 100%;
+}
+
+.digitalBilling {
+  align-items: center;
+  box-shadow: 1px -2px 5px 3px $shadow-color !important;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 8px;
+  justify-content: space-between;
+  margin-top: 40px;
+  width: 100%;
+
+  .title {
+    font-size: $large;
+    font-weight: 600;
+  }
+
+  .subscriptionTag {
+    align-items: center;
+    border-radius: 8px;
+    display: flex;
+    font-size: $small;
+    overflow: hidden;
+    padding: 4px 6px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: fit-content;
+
+    &-error {
+      @extend .subscriptionTag;
+      background-color: $primary-variant-3;
+      color: $error;
+
+      span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+
+    &-success {
+      @extend .subscriptionTag;
+      background-color: $primary-text-button-hover;
+      color: $input-primary;
+
+      span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+
+    .icon {
+      height: 16px;
+      margin-right: 4px;
+      width: 16px;
+  
+      &-error {
+        @extend .icon;
+        color: $error;
+      }
+  
+      &-success {
+        @extend .icon;
+        color: $input-primary;
+      }
+    }
+  }
+
+  .emailList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+
+    > li {
+      color: $gray;
+      font-size: $medium;
+      font-weight: 300;
+      overflow: hidden;
+      padding-left: 8px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      ::marker {
+        margin: 0 8px;
+      }
+    }
+  }
+
+  .buttonsBox {
+    display: flex;
+    flex-flow: row nowrap;
+    gap: 8px;
+    justify-content: center;
+    margin-left: auto;
+    margin-top: 16px;
+    width: 100%;
+
+    .digitalBillingButtons {
+      @extend %buttons;
+      font-size: $medium;
+      max-width: 160px;
+      min-width: 90px;
+      width: 50%;
+
+      &-modify {
+        @extend .digitalBillingButtons;
+        background-color: $loading-base;
+        color: $account-status-action-card;
+      }
+      
+      &-unsubscribe {
+        @extend .digitalBillingButtons;
+        background-color: $error;
+        color: $white;
+      }
+      
+      &-subscribe {
+        @extend .digitalBillingButtons;
+        background-color: $primary-text-button-hover;
+        color: $input-primary;
+      }
+    }
+  }
+}
+
+@media #{$desktop-tablet} {
+  .digitalBilling {
+    .buttonsBox {
+      justify-content: flex-end;
+    }
+  }
+}

--- a/src/app/screens/Home/components/DigitalBilling/styles.module.scss
+++ b/src/app/screens/Home/components/DigitalBilling/styles.module.scss
@@ -12,7 +12,7 @@
   box-shadow: 1px -2px 5px 3px $shadow-color !important;
   display: flex;
   flex-flow: row wrap;
-  gap: 8px;
+  gap: 8px; //sass-lint:disable-line no-misspelled-properties
   justify-content: space-between;
   margin-top: 40px;
   width: 100%;
@@ -61,12 +61,12 @@
       height: 16px;
       margin-right: 4px;
       width: 16px;
-  
+
       &-error {
         @extend .icon;
         color: $error;
       }
-  
+
       &-success {
         @extend .icon;
         color: $input-primary;
@@ -98,7 +98,7 @@
   .buttonsBox {
     display: flex;
     flex-flow: row nowrap;
-    gap: 8px;
+    gap: 8px; //sass-lint:disable-line no-misspelled-properties
     justify-content: center;
     margin-left: auto;
     margin-top: 16px;
@@ -116,13 +116,13 @@
         background-color: $loading-base;
         color: $account-status-action-card;
       }
-      
+
       &-unsubscribe {
         @extend .digitalBillingButtons;
         background-color: $error;
         color: $white;
       }
-      
+
       &-subscribe {
         @extend .digitalBillingButtons;
         background-color: $primary-text-button-hover;

--- a/src/app/screens/Home/components/DigitalBilling/styles.module.scss
+++ b/src/app/screens/Home/components/DigitalBilling/styles.module.scss
@@ -129,12 +129,8 @@
         color: $input-primary;
       }
     }
-  }
-}
 
-@media #{$desktop-tablet} {
-  .digitalBilling {
-    .buttonsBox {
+    @media #{$desktop-tablet} {
       justify-content: flex-end;
     }
   }

--- a/src/app/screens/Home/components/DigitalBillingModal/index.js
+++ b/src/app/screens/Home/components/DigitalBillingModal/index.js
@@ -1,0 +1,47 @@
+import { UTLabel } from '@widergy/energy-ui';
+import React from 'react';
+import { arrayOf, bool, func, string } from 'prop-types';
+
+import Modal from 'app/components/Modal';
+import { modalTypes } from 'types/modalTypes';
+
+import styles from './styles.module.scss';
+
+const DigitalBillingModal = ({
+  children,
+  contactEmails,
+  disableCta,
+  handleCancel,
+  handleCta,
+  modalState
+}) => (
+  <Modal
+    cancelText={modalState.cancelText}
+    ctaText={modalState.ctaText}
+    disableCta={disableCta}
+    handleCancel={handleCancel}
+    handleCta={() => handleCta(modalState.action)}
+  >
+    <UTLabel classes={{ root: styles['modal-title'] }}>{modalState.title}</UTLabel>
+    <div className={styles['modal-body']}>
+      <UTLabel classes={{ root: styles['modal-content'] }}>{modalState.body}</UTLabel>
+      {modalState.action === 'modify' &&
+        contactEmails.map(email => (
+          <UTLabel key={email} classes={{ root: styles['modal-emails'] }}>
+            {email}
+          </UTLabel>
+        ))}
+      {children}
+    </div>
+  </Modal>
+);
+
+DigitalBillingModal.propTypes = {
+  contactEmails: arrayOf(string),
+  disableCta: bool,
+  handleCancel: func,
+  handleCta: func,
+  modalState: modalTypes
+};
+
+export default DigitalBillingModal;

--- a/src/app/screens/Home/components/DigitalBillingModal/index.js
+++ b/src/app/screens/Home/components/DigitalBillingModal/index.js
@@ -1,6 +1,7 @@
 import { UTLabel } from '@widergy/energy-ui';
 import React from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
+import i18 from 'i18next';
 
 import Modal from 'app/components/Modal';
 import { modalTypes } from 'types/modalTypes';
@@ -16,8 +17,8 @@ const DigitalBillingModal = ({
   modalState
 }) => (
   <Modal
-    cancelText={modalState.cancelText}
-    ctaText={modalState.ctaText}
+    cancelText={i18.t('digitalBills:modal.cancel')}
+    ctaText={i18.t('digitalBills:modal.accept')}
     disableCta={disableCta}
     handleCancel={handleCancel}
     handleCta={() => handleCta(modalState.action)}

--- a/src/app/screens/Home/components/DigitalBillingModal/styles.module.scss
+++ b/src/app/screens/Home/components/DigitalBillingModal/styles.module.scss
@@ -1,0 +1,31 @@
+@import 'scss/variables/_sizes.scss';
+@import 'scss/variables/_fontSizes.scss';
+@import '_colors.scss';
+
+.modal {
+  &-title {
+    color: $primary-variant-3;
+    font-size: $large;
+    margin: 0 auto;
+    font-weight: 600;
+    text-align: center;
+    width: fit-content;
+  }
+
+  &-body {
+    margin: 16px 0;
+    width: 100%;
+
+    .modal-content {
+      color: $white;
+      font-size: $medium;
+      width: fit-content;
+    }
+  }
+
+  &-emails {
+    font-size: $small;
+    margin: 8px 0;
+    padding-left: 8px;
+  }
+}

--- a/src/app/screens/Home/constants.js
+++ b/src/app/screens/Home/constants.js
@@ -2,31 +2,19 @@ import i18 from 'i18next';
 
 export const modalState = {
   modify: {
-    showModal: true,
     action: 'modify',
-    cancelText: i18.t('digitalBills:modal.cancel'),
-    ctaText: i18.t('digitalBills:modal.accept'),
     title: i18.t('digitalBills:modal.modifyTitle'),
     body: i18.t('digitalBills:modal.modifyCurrent')
   },
   subscribe: {
-    showModal: true,
     action: 'subscribe',
-    cancelText: i18.t('digitalBills:modal.cancel'),
-    ctaText: i18.t('digitalBills:modal.accept'),
     title: i18.t('digitalBills:modal.subscribeTitle'),
     body: i18.t('digitalBills:modal.subscribeBody')
   },
   unsubscribe: {
-    showModal: true,
     action: 'unsubscribe',
-    cancelText: i18.t('digitalBills:modal.cancel'),
-    ctaText: i18.t('digitalBills:modal.accept'),
     title: i18.t('digitalBills:modal.unsubscribeTitle'),
     body: i18.t('digitalBills:modal.unsubscribeBody')
-  },
-  closed: {
-    showModal: false
   }
 };
 

--- a/src/app/screens/Home/constants.js
+++ b/src/app/screens/Home/constants.js
@@ -1,0 +1,42 @@
+import i18 from 'i18next';
+
+export const modalState = {
+  modify: {
+    showModal: true,
+    action: 'modify',
+    cancelText: i18.t('digitalBills:modal.cancel'),
+    ctaText: i18.t('digitalBills:modal.accept'),
+    title: i18.t('digitalBills:modal.modifyTitle'),
+    body: i18.t('digitalBills:modal.modifyCurrent')
+  },
+  subscribe: {
+    showModal: true,
+    action: 'subscribe',
+    cancelText: i18.t('digitalBills:modal.cancel'),
+    ctaText: i18.t('digitalBills:modal.accept'),
+    title: i18.t('digitalBills:modal.subscribeTitle'),
+    body: i18.t('digitalBills:modal.subscribeBody')
+  },
+  unsubscribe: {
+    showModal: true,
+    action: 'unsubscribe',
+    cancelText: i18.t('digitalBills:modal.cancel'),
+    ctaText: i18.t('digitalBills:modal.accept'),
+    title: i18.t('digitalBills:modal.unsubscribeTitle'),
+    body: i18.t('digitalBills:modal.unsubscribeBody')
+  },
+  closed: {
+    showModal: false
+  }
+};
+
+export const tagState = {
+  success: {
+    status: 'success',
+    text: i18.t('digitalBills:digitalBillSubscribed')
+  },
+  error: {
+    status: 'error',
+    text: i18.t('digitalBills:digitalBillNotSubscribed')
+  }
+};

--- a/src/app/screens/Home/index.js
+++ b/src/app/screens/Home/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useMemo, useReducer, useState } from 'react';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { UTButton, UTLabel, UTLoading } from '@widergy/energy-ui';
@@ -9,17 +9,19 @@ import i18 from 'i18next';
 import DescriptionIcon from '@material-ui/icons/Description';
 
 import appConfig from 'config/appConfig';
-import Modal from 'app/components/Modal';
 import { BILLS_HISTORY } from 'constants/routes';
 import AccountActions from 'redux/accounts/actions';
 import BillsActions from 'redux/bills/actions';
 import CurrentAccount from 'app/components/CurrentAccount';
 import { billType } from 'types/billsTypes';
 import { accountType } from 'types/accountTypes';
+import { digitalBillingType } from 'types/digitalBillingTypes';
 
+import { modalState, tagState } from './constants';
 import DigitalBilling from './components/DigitalBilling';
 import LastBill from './components/LastBill';
 import styles from './styles.module.scss';
+import DigitalBillingModal from './components/DigitalBillingModal';
 
 const Home = ({
   accounts,
@@ -29,124 +31,70 @@ const Home = ({
   dispatch,
   lastBill,
   lastBillError,
-  lastBillloading
+  lastBillloading,
+  digitalBilling,
+  digitalBillingLoading
 }) => {
   useEffect(() => {
     if (isEmpty(accounts) && !accountsError && !accountsLoading) dispatch(AccountActions.getAccounts());
     if (objectIsEmpty(lastBill) && !lastBillError && !lastBillloading) dispatch(BillsActions.getLastBill());
   }, []);
 
+  useEffect(() => {
+    if (!objectIsEmpty(currentAccount)) {
+      dispatch(
+        BillsActions.setDigitalBilling({
+          adherido_factura_digital: currentAccount.adherido_factura_digital,
+          contact_emails: currentAccount.contact_emails
+        })
+      );
+    }
+  }, [currentAccount]);
+
+  const [tagStatus, setTagStatus] = useState({});
+
+  useEffect(() => {
+    if (digitalBilling.adherido_factura_digital) {
+      setTagStatus(tagState.success);
+    } else {
+      setTagStatus(tagState.error);
+    }
+  }, [digitalBilling]);
+
   const [inputValue, setInputValue] = useState('');
+  const [modalStatus, setModalStatus] = useState(modalState.closed);
+
+  const handleCta = action => {
+    if (action === 'modify') {
+      dispatch(BillsActions.digitalBillingUpdate(inputValue));
+      setModalStatus(modalState.closed);
+    }
+
+    if (action === 'subscribe') {
+      dispatch(BillsActions.digitalBillingSubscription(inputValue));
+      setModalStatus(modalState.closed);
+    }
+
+    if (action === 'unsubscribe') {
+      dispatch(BillsActions.digitalBillingUnsubscription(inputValue));
+      setModalStatus(modalState.closed);
+    }
+  };
+
+  const openModal = action => {
+    setModalStatus(modalState[action]);
+  };
 
   const handleInput = e => {
-    setInputValue(`${inputValue}${e.target.value}`);
+    setInputValue(e.target.value);
   };
 
   const validateEmail = useMemo(() => !!inputValue.match(/^\S+@\S+\.\S+$/), [inputValue]);
 
-  const modalReducer = (modalState, action) => {
-    switch (action.type) {
-      case 'modify':
-        return {
-          showModal: true,
-          cancelText: i18.t('Home:modal.cancel'),
-          ctaText: i18.t('Home:modal.accept'),
-          handleCta: (email, profile, close = () => {}) => {
-            dispatch(AccountActions.digitalBillingUpdate(email, profile));
-            close();
-          },
-          body: (
-            <Fragment>
-              <UTLabel classes={{ root: styles['modal-title'] }}>{i18.t('Home:modal.modifyTitle')}</UTLabel>
-              <div className={styles['modal-body']}>
-                <UTLabel classes={{ root: styles['modal-content'] }}>
-                  {i18.t('Home:modal.modifyCurrent')}
-                </UTLabel>
-                {currentAccount.contact_emails.map(email => (
-                  <UTLabel key={email} classes={{ root: styles['modal-emails'] }}>
-                    {email}
-                  </UTLabel>
-                ))}
-                <UTLabel classes={{ root: styles['modal-content'] }}>{i18.t('Home:modal.modifyNew')}</UTLabel>
-              </div>
-              <input
-                type="email"
-                onChange={handleInput}
-                placeholder={i18.t('Home:modal.emailPlaceholder')}
-                className={styles['modal-input']}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus
-              />
-            </Fragment>
-          )
-        };
-      case 'unsubscribe':
-        return {
-          showModal: true,
-          buttonDisable: false,
-          cancelText: i18.t('Home:modal.cancel'),
-          ctaText: i18.t('Home:modal.accept'),
-          handleCta: (email, profile, close = () => {}) => {
-            dispatch(AccountActions.digitalBillingUnsubscription(email, profile));
-            close();
-          },
-          body: (
-            <Fragment>
-              <UTLabel classes={{ root: styles['modal-title'] }}>
-                {i18.t('Home:modal.unsubscribeTitle')}
-              </UTLabel>
-              <div className={styles['modal-body']}>
-                <UTLabel classes={{ root: styles['modal-content'] }}>
-                  {i18.t('Home:modal.unsubscribeBody')}
-                </UTLabel>
-              </div>
-            </Fragment>
-          )
-        };
-      case 'subscribe':
-        return {
-          showModal: true,
-          cancelText: i18.t('Home:modal.cancel'),
-          ctaText: i18.t('Home:modal.accept'),
-          handleCta: (email, profile, close = () => {}) => {
-            dispatch(AccountActions.digitalBillingSubscription(email, profile));
-            close();
-          },
-          body: (
-            <Fragment>
-              <UTLabel classes={{ root: styles['modal-title'] }}>
-                {i18.t('Home:modal.subscribeTitle')}
-              </UTLabel>
-              <div className={styles['modal-body']}>
-                <UTLabel classes={{ root: styles['modal-content'] }}>
-                  {i18.t('Home:modal.subscribeBody')}
-                </UTLabel>
-              </div>
-              <input
-                type="email"
-                onChange={handleInput}
-                placeholder={i18.t('Home:modal.emailPlaceholder')}
-                className={styles['modal-input']}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus
-              />
-            </Fragment>
-          )
-        };
-      case 'close':
-        setInputValue('');
-        return {
-          showModal: false
-        };
-      default:
-        return modalState;
-    }
+  const handleCancel = () => {
+    setModalStatus(modalState.closed);
+    setInputValue('');
   };
-
-  const [modalState, reducerDispatch] = useReducer(modalReducer, { showModal: false });
-
-  const handleCancel = () => reducerDispatch({ type: 'close' });
-  const openModal = type => reducerDispatch({ type });
 
   return (
     <Fragment>
@@ -161,11 +109,13 @@ const Home = ({
               <CurrentAccount currentAccount={currentAccount} />
               {appConfig.digitalBilling.enabled && (
                 <DigitalBilling
-                  emails={currentAccount.contact_emails}
+                  loading={digitalBillingLoading}
+                  emails={digitalBilling.contact_emails}
                   handleModify={() => openModal('modify')}
                   handleSubscribe={() => openModal('subscribe')}
                   handleUnsubscribe={() => openModal('unsubscribe')}
-                  subscription={currentAccount.adherido_factura_digital}
+                  subscription={digitalBilling.adherido_factura_digital}
+                  tagState={tagStatus}
                 />
               )}
               <div className={styles.content}>
@@ -187,18 +137,33 @@ const Home = ({
         </UTLoading>
       </div>
 
-      {modalState.showModal && currentAccount && (
-        <Modal
-          cancelText={modalState.cancelText}
-          ctaText={modalState.ctaText}
-          disableCta={modalState.buttonDisable ?? !validateEmail}
+      {modalStatus.showModal && currentAccount && (
+        <DigitalBillingModal
+          contactEmails={currentAccount.contact_emails}
+          disableCta={modalStatus.action === 'unsubscribe' ? false : !validateEmail}
           handleCancel={handleCancel}
-          handleCta={() =>
-            modalState.handleCta(inputValue, currentAccount.perfil, reducerDispatch({ type: 'close' }))
-          }
+          handleCta={handleCta}
+          modalState={modalStatus}
         >
-          <div className={styles.modalBody}>{modalState.body}</div>
-        </Modal>
+          {modalStatus.action !== 'unsubscribe' && (
+            <Fragment>
+              <UTLabel classes={{ root: styles['modal-content'] }}>
+                {i18.t('digitalBills:modal.modifyNew')}
+              </UTLabel>
+              <input
+                type="email"
+                onChange={handleInput}
+                placeholder={i18.t('digitalBills:modal.emailPlaceholder')}
+                className={styles.input}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+              />
+              {!validateEmail && !!inputValue.length && (
+                <span className={styles.validation}>Email invalido</span>
+              )}
+            </Fragment>
+          )}
+        </DigitalBillingModal>
       )}
     </Fragment>
   );
@@ -211,7 +176,9 @@ Home.propTypes = {
   currentAccount: accountType,
   lastBill: billType,
   lastBillError: string,
-  lastBillloading: bool
+  lastBillloading: bool,
+  digitalBilling: digitalBillingType,
+  digitalBillingLoading: bool
 };
 
 const mapStateToProps = store => ({
@@ -221,7 +188,9 @@ const mapStateToProps = store => ({
   lastBill: store.bills.lastBill,
   lastBillError: store.bills.lastBillError,
   lastBillLoading: store.bills.lastBillLoading,
-  accountsLoading: store.accounts.accountsLoading
+  accountsLoading: store.accounts.accountsLoading,
+  digitalBilling: store.bills.digitalBilling,
+  digitalBillingLoading: store.bills.digitalBillingLoading
 });
 
 export default connect(mapStateToProps)(Home);

--- a/src/app/screens/Home/index.js
+++ b/src/app/screens/Home/index.js
@@ -62,27 +62,21 @@ const Home = ({
   }, [digitalBilling]);
 
   const [inputValue, setInputValue] = useState('');
-  const [modalStatus, setModalStatus] = useState(modalState.closed);
+  const [modalDefinitions, setModalDefinitions] = useState(modalState.closed);
 
   const handleCta = action => {
-    if (action === 'modify') {
-      dispatch(BillsActions.digitalBillingUpdate(inputValue));
-      setModalStatus(modalState.closed);
-    }
+    if (action === 'modify') dispatch(BillsActions.digitalBillingUpdate(inputValue));
 
-    if (action === 'subscribe') {
-      dispatch(BillsActions.digitalBillingSubscription(inputValue));
-      setModalStatus(modalState.closed);
-    }
+    if (action === 'subscribe') dispatch(BillsActions.digitalBillingSubscription(inputValue));
 
-    if (action === 'unsubscribe') {
-      dispatch(BillsActions.digitalBillingUnsubscription(inputValue));
-      setModalStatus(modalState.closed);
-    }
+    if (action === 'unsubscribe') dispatch(BillsActions.digitalBillingUnsubscription(inputValue));
+
+    setModalDefinitions(modalState.closed);
+    setInputValue('');
   };
 
   const openModal = action => {
-    setModalStatus(modalState[action]);
+    setModalDefinitions(modalState[action]);
   };
 
   const handleInput = e => {
@@ -92,7 +86,7 @@ const Home = ({
   const validateEmail = useMemo(() => !!inputValue.match(/^\S+@\S+\.\S+$/), [inputValue]);
 
   const handleCancel = () => {
-    setModalStatus(modalState.closed);
+    setModalDefinitions(modalState.closed);
     setInputValue('');
   };
 
@@ -137,15 +131,15 @@ const Home = ({
         </UTLoading>
       </div>
 
-      {modalStatus.showModal && currentAccount && (
+      {modalDefinitions && currentAccount && (
         <DigitalBillingModal
           contactEmails={currentAccount.contact_emails}
-          disableCta={modalStatus.action === 'unsubscribe' ? false : !validateEmail}
+          disableCta={modalDefinitions.action === 'unsubscribe' ? false : !validateEmail}
           handleCancel={handleCancel}
           handleCta={handleCta}
-          modalState={modalStatus}
+          modalState={modalDefinitions}
         >
-          {modalStatus.action !== 'unsubscribe' && (
+          {modalDefinitions.action !== 'unsubscribe' && (
             <Fragment>
               <UTLabel classes={{ root: styles['modal-content'] }}>
                 {i18.t('digitalBills:modal.modifyNew')}
@@ -159,7 +153,7 @@ const Home = ({
                 autoFocus
               />
               {!validateEmail && !!inputValue.length && (
-                <span className={styles.validation}>Email invalido</span>
+                <span className={styles.validation}>{i18.t('digitalBills:modal.validation')}</span>
               )}
             </Fragment>
           )}

--- a/src/app/screens/Home/index.js
+++ b/src/app/screens/Home/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useMemo, useReducer, useState } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { UTButton, UTLabel, UTLoading } from '@widergy/energy-ui';
@@ -8,6 +8,8 @@ import { objectIsEmpty } from '@widergy/web-utils/lib/object';
 import i18 from 'i18next';
 import DescriptionIcon from '@material-ui/icons/Description';
 
+import appConfig from 'config/appConfig';
+import Modal from 'app/components/Modal';
 import { BILLS_HISTORY } from 'constants/routes';
 import AccountActions from 'redux/accounts/actions';
 import BillsActions from 'redux/bills/actions';
@@ -15,6 +17,7 @@ import CurrentAccount from 'app/components/CurrentAccount';
 import { billType } from 'types/billsTypes';
 import { accountType } from 'types/accountTypes';
 
+import DigitalBilling from './components/DigitalBilling';
 import LastBill from './components/LastBill';
 import styles from './styles.module.scss';
 
@@ -33,34 +36,171 @@ const Home = ({
     if (objectIsEmpty(lastBill) && !lastBillError && !lastBillloading) dispatch(BillsActions.getLastBill());
   }, []);
 
+  const [inputValue, setInputValue] = useState('');
+
+  const handleInput = e => {
+    setInputValue(`${inputValue}${e.target.value}`);
+  };
+
+  const validateEmail = useMemo(() => !!inputValue.match(/^\S+@\S+\.\S+$/), [inputValue]);
+
+  const modalReducer = (modalState, action) => {
+    switch (action.type) {
+      case 'modify':
+        return {
+          showModal: true,
+          cancelText: i18.t('Home:modal.cancel'),
+          ctaText: i18.t('Home:modal.accept'),
+          handleCta: (email, profile, close = () => {}) => {
+            dispatch(AccountActions.digitalBillingUpdate(email, profile));
+            close();
+          },
+          body: (
+            <Fragment>
+              <UTLabel classes={{ root: styles['modal-title'] }}>{i18.t('Home:modal.modifyTitle')}</UTLabel>
+              <div className={styles['modal-body']}>
+                <UTLabel classes={{ root: styles['modal-content'] }}>
+                  {i18.t('Home:modal.modifyCurrent')}
+                </UTLabel>
+                {currentAccount.contact_emails.map(email => (
+                  <UTLabel key={email} classes={{ root: styles['modal-emails'] }}>
+                    {email}
+                  </UTLabel>
+                ))}
+                <UTLabel classes={{ root: styles['modal-content'] }}>{i18.t('Home:modal.modifyNew')}</UTLabel>
+              </div>
+              <input
+                type="email"
+                onChange={handleInput}
+                placeholder={i18.t('Home:modal.emailPlaceholder')}
+                className={styles['modal-input']}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+              />
+            </Fragment>
+          )
+        };
+      case 'unsubscribe':
+        return {
+          showModal: true,
+          buttonDisable: false,
+          cancelText: i18.t('Home:modal.cancel'),
+          ctaText: i18.t('Home:modal.accept'),
+          handleCta: (email, profile, close = () => {}) => {
+            dispatch(AccountActions.digitalBillingUnsubscription(email, profile));
+            close();
+          },
+          body: (
+            <Fragment>
+              <UTLabel classes={{ root: styles['modal-title'] }}>
+                {i18.t('Home:modal.unsubscribeTitle')}
+              </UTLabel>
+              <div className={styles['modal-body']}>
+                <UTLabel classes={{ root: styles['modal-content'] }}>
+                  {i18.t('Home:modal.unsubscribeBody')}
+                </UTLabel>
+              </div>
+            </Fragment>
+          )
+        };
+      case 'subscribe':
+        return {
+          showModal: true,
+          cancelText: i18.t('Home:modal.cancel'),
+          ctaText: i18.t('Home:modal.accept'),
+          handleCta: (email, profile, close = () => {}) => {
+            dispatch(AccountActions.digitalBillingSubscription(email, profile));
+            close();
+          },
+          body: (
+            <Fragment>
+              <UTLabel classes={{ root: styles['modal-title'] }}>
+                {i18.t('Home:modal.subscribeTitle')}
+              </UTLabel>
+              <div className={styles['modal-body']}>
+                <UTLabel classes={{ root: styles['modal-content'] }}>
+                  {i18.t('Home:modal.subscribeBody')}
+                </UTLabel>
+              </div>
+              <input
+                type="email"
+                onChange={handleInput}
+                placeholder={i18.t('Home:modal.emailPlaceholder')}
+                className={styles['modal-input']}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+              />
+            </Fragment>
+          )
+        };
+      case 'close':
+        setInputValue('');
+        return {
+          showModal: false
+        };
+      default:
+        return modalState;
+    }
+  };
+
+  const [modalState, reducerDispatch] = useReducer(modalReducer, { showModal: false });
+
+  const handleCancel = () => reducerDispatch({ type: 'close' });
+  const openModal = type => reducerDispatch({ type });
+
   return (
-    <div className={styles.container}>
-      <UTLoading loading={accountsLoading || lastBillloading}>
-        {accountsError ? (
-          <UTLabel>{accountsError}</UTLabel>
-        ) : isEmpty(accounts) ? (
-          <UTLabel>{i18.t('Home:noAccounts')}</UTLabel>
-        ) : (
-          <Fragment>
-            <CurrentAccount currentAccount={currentAccount} />
-            <div className={styles.content}>
-              <div className={styles.leftSection}>
-                <UTButton
-                  onClick={() => dispatch(push(BILLS_HISTORY))}
-                  classNames={{ root: styles.billsListButton }}
-                  Icon={DescriptionIcon}
-                >
-                  {i18.t('Bills:goToHistory')}
-                </UTButton>
+    <Fragment>
+      <div className={styles.container}>
+        <UTLoading loading={accountsLoading || lastBillloading}>
+          {accountsError ? (
+            <UTLabel>{accountsError}</UTLabel>
+          ) : isEmpty(accounts) ? (
+            <UTLabel>{i18.t('Home:noAccounts')}</UTLabel>
+          ) : (
+            <Fragment>
+              <CurrentAccount currentAccount={currentAccount} />
+              {appConfig.digitalBilling.enabled && (
+                <DigitalBilling
+                  emails={currentAccount.contact_emails}
+                  handleModify={() => openModal('modify')}
+                  handleSubscribe={() => openModal('subscribe')}
+                  handleUnsubscribe={() => openModal('unsubscribe')}
+                  subscription={currentAccount.adherido_factura_digital}
+                />
+              )}
+              <div className={styles.content}>
+                <div className={styles.leftSection}>
+                  <UTButton
+                    classNames={{ root: styles.billsListButton }}
+                    Icon={DescriptionIcon}
+                    onClick={() => dispatch(push(BILLS_HISTORY))}
+                  >
+                    {i18.t('Bills:goToHistory')}
+                  </UTButton>
+                </div>
+                <div className={styles.rightSection}>
+                  <LastBill currentBill={lastBill} loading={lastBillloading} />
+                </div>
               </div>
-              <div className={styles.rightSection}>
-                <LastBill currentBill={lastBill} loading={lastBillloading} />
-              </div>
-            </div>
-          </Fragment>
-        )}
-      </UTLoading>
-    </div>
+            </Fragment>
+          )}
+        </UTLoading>
+      </div>
+
+      {modalState.showModal && currentAccount && (
+        <Modal
+          cancelText={modalState.cancelText}
+          ctaText={modalState.ctaText}
+          disableCta={modalState.buttonDisable ?? !validateEmail}
+          handleCancel={handleCancel}
+          handleCta={() =>
+            modalState.handleCta(inputValue, currentAccount.perfil, reducerDispatch({ type: 'close' }))
+          }
+        >
+          <div className={styles.modalBody}>{modalState.body}</div>
+        </Modal>
+      )}
+    </Fragment>
   );
 };
 

--- a/src/app/screens/Home/styles.module.scss
+++ b/src/app/screens/Home/styles.module.scss
@@ -1,4 +1,6 @@
 @import 'scss/variables/_sizes.scss';
+@import 'scss/variables/_fontSizes.scss';
+@import 'scss/variables/_mediaQueries.scss';
 @import '_colors.scss';
 
 $margin-size: 40px;
@@ -37,4 +39,48 @@ $margin-size: 40px;
 
 .billsListButton {
   @extend %buttons;
+}
+
+.modal {
+  &-title {
+    color: $primary-variant-3;
+    font-size: $large;
+    margin: 0 auto;
+    font-weight: 600;
+    text-align: center;
+    width: fit-content;
+  }
+
+  &-body {
+    margin: 16px 0;
+    width: fit-content;
+
+    .modal-content {
+      color: $white;
+      font-size: $medium;
+      width: fit-content;
+    }
+  }
+
+  &-emails {
+    font-size: $small;
+    margin: 8px 0;
+    padding-left: 8px;
+  }
+
+  &-input {
+    background-color: transparent;
+    border: 0;
+    border-bottom: 2px solid $input-primary;
+    color: $white;
+    width: 100%;
+
+    &::placeholder {
+      color: $white;
+    }
+
+    &:focus-visible {
+      outline: unset;
+    }
+  }
 }

--- a/src/app/screens/Home/styles.module.scss
+++ b/src/app/screens/Home/styles.module.scss
@@ -41,46 +41,30 @@ $margin-size: 40px;
   @extend %buttons;
 }
 
-.modal {
-  &-title {
-    color: $primary-variant-3;
-    font-size: $large;
-    margin: 0 auto;
-    font-weight: 600;
-    text-align: center;
-    width: fit-content;
-  }
+.input {
+  background-color: transparent;
+  border: 0;
+  border-bottom: 2px solid $input-primary;
+  color: $white;
+  width: 100%;
 
-  &-body {
-    margin: 16px 0;
-    width: fit-content;
-
-    .modal-content {
-      color: $white;
-      font-size: $medium;
-      width: fit-content;
-    }
-  }
-
-  &-emails {
-    font-size: $small;
-    margin: 8px 0;
-    padding-left: 8px;
-  }
-
-  &-input {
-    background-color: transparent;
-    border: 0;
-    border-bottom: 2px solid $input-primary;
+  &::placeholder {
     color: $white;
-    width: 100%;
-
-    &::placeholder {
-      color: $white;
-    }
-
-    &:focus-visible {
-      outline: unset;
-    }
   }
+
+  &:focus-visible {
+    outline: unset;
+  }
+}
+
+.validation {
+  align-self: flex-start;
+  color: $error;
+  font-size: $small;
+}
+
+.modal-content {
+  color: $white;
+  font-size: $medium;
+  width: fit-content;
 }

--- a/src/config/idinir/config.js
+++ b/src/config/idinir/config.js
@@ -14,5 +14,8 @@ export default {
   },
   billsHistory: {
     enabled: true
+  },
+  digitalBilling: {
+    enabled: true
   }
 };

--- a/src/config/idinir/texts.js
+++ b/src/config/idinir/texts.js
@@ -14,7 +14,25 @@ export default {
       amount_to_pay: 'Monto a pagar'
     },
     Home: {
-      noAccounts: 'No hay cuentas'
+      digitalBilling: 'Facturación digital',
+      digitalBillingModify: 'Modificar',
+      digitalBillingSubscribe: 'Adhesión',
+      digitalBillingUnsubscribe: 'Baja',
+      digitalBillNotSubscribed: 'No adherido a factura digital',
+      digitalBillSubscribed: 'Adherido a factura digital',
+      noAccounts: 'No hay cuentas',
+      modal: {
+        accept: 'Aceptar',
+        cancel: 'Cancelar',
+        emailPlaceholder: 'Nuevo email',
+        modifyCurrent: 'Su Email actual es:',
+        modifyNew: 'Ingrese el nuevo mail a adherir:',
+        modifyTitle: 'Modificar adhesión a factura digital',
+        subscribeTitle: 'Adhesión a factura digital',
+        subscribeBody: 'Ingrese el email en el cual quiere recibir su factura',
+        unsubscribeBody: 'Usted está a punto de deshaderirse de factura digital',
+        unsubscribeTitle: 'Baja de factura digital'
+      }
     }
   }
 };

--- a/src/config/idinir/texts.js
+++ b/src/config/idinir/texts.js
@@ -14,13 +14,15 @@ export default {
       amount_to_pay: 'Monto a pagar'
     },
     Home: {
+      noAccounts: 'No hay cuentas'
+    },
+    digitalBills: {
       digitalBilling: 'Facturación digital',
       digitalBillingModify: 'Modificar',
       digitalBillingSubscribe: 'Adhesión',
       digitalBillingUnsubscribe: 'Baja',
       digitalBillNotSubscribed: 'No adherido a factura digital',
       digitalBillSubscribed: 'Adherido a factura digital',
-      noAccounts: 'No hay cuentas',
       modal: {
         accept: 'Aceptar',
         cancel: 'Cancelar',

--- a/src/config/idinir/texts.js
+++ b/src/config/idinir/texts.js
@@ -33,7 +33,8 @@ export default {
         subscribeTitle: 'Adhesión a factura digital',
         subscribeBody: 'Ingrese el email en el cual quiere recibir su factura',
         unsubscribeBody: 'Usted está a punto de deshaderirse de factura digital',
-        unsubscribeTitle: 'Baja de factura digital'
+        unsubscribeTitle: 'Baja de factura digital',
+        validation: 'Email invalido'
       }
     }
   }

--- a/src/config/segba/config.js
+++ b/src/config/segba/config.js
@@ -14,5 +14,8 @@ export default {
   },
   billsHistory: {
     enabled: false
+  },
+  digitalBilling: {
+    enabled: false
   }
 };

--- a/src/config/segba/scss/_colors.scss
+++ b/src/config/segba/scss/_colors.scss
@@ -15,6 +15,10 @@ $primary-variant-1: #25A7C1;
 $primary-variant-2: #27158E;
 $primary-variant-3: #0083D5;
 
+$light-01: #E6DCC2;
+$gradient-vertical: 'linear-gradient(90deg, rgba(208,183,52,1) 6%, rgba(253,115,29,1) 41%, rgba(177,128,0,1) 73%)';
+$account-status-action-card: #FD731D;
+
 $shadow-color: #BFC3C8;
 
 // sass-lint:disable no-misspelled-properties

--- a/src/config/segba/texts.js
+++ b/src/config/segba/texts.js
@@ -14,13 +14,15 @@ export default {
       amount_to_pay: 'Monto a pagar'
     },
     Home: {
+      noAccounts: 'No hay cuentas'
+    },
+    digitalBilling: {
       digitalBilling: 'Facturación digital',
       digitalBillingModify: 'Modificar',
       digitalBillingSubscribe: 'Adhesión',
       digitalBillingUnsubscribe: 'Baja',
-      digitalBillSubscribed: 'Adherido a factura digital',
       digitalBillNotSubscribed: 'No adherido a factura digital',
-      noAccounts: 'No hay cuentas',
+      digitalBillSubscribed: 'Adherido a factura digital',
       modal: {
         accept: 'Aceptar',
         cancel: 'Cancelar',
@@ -28,8 +30,8 @@ export default {
         modifyCurrent: 'Su Email actual es:',
         modifyNew: 'Ingrese el nuevo mail a adherir:',
         modifyTitle: 'Modificar adhesión a factura digital',
-        subscribeBody: 'Ingrese el email en el cual quiere recibir su factura',
         subscribeTitle: 'Adhesión a factura digital',
+        subscribeBody: 'Ingrese el email en el cual quiere recibir su factura',
         unsubscribeBody: 'Usted está a punto de deshaderirse de factura digital',
         unsubscribeTitle: 'Baja de factura digital'
       }

--- a/src/config/segba/texts.js
+++ b/src/config/segba/texts.js
@@ -14,7 +14,25 @@ export default {
       amount_to_pay: 'Monto a pagar'
     },
     Home: {
-      noAccounts: 'No hay cuentas'
+      digitalBilling: 'Facturación digital',
+      digitalBillingModify: 'Modificar',
+      digitalBillingSubscribe: 'Adhesión',
+      digitalBillingUnsubscribe: 'Baja',
+      digitalBillSubscribed: 'Adherido a factura digital',
+      digitalBillNotSubscribed: 'No adherido a factura digital',
+      noAccounts: 'No hay cuentas',
+      modal: {
+        accept: 'Aceptar',
+        cancel: 'Cancelar',
+        emailPlaceholder: 'Nuevo email',
+        modifyCurrent: 'Su Email actual es:',
+        modifyNew: 'Ingrese el nuevo mail a adherir:',
+        modifyTitle: 'Modificar adhesión a factura digital',
+        subscribeBody: 'Ingrese el email en el cual quiere recibir su factura',
+        subscribeTitle: 'Adhesión a factura digital',
+        unsubscribeBody: 'Usted está a punto de deshaderirse de factura digital',
+        unsubscribeTitle: 'Baja de factura digital'
+      }
     }
   }
 };

--- a/src/config/segba/texts.js
+++ b/src/config/segba/texts.js
@@ -33,7 +33,8 @@ export default {
         subscribeTitle: 'Adhesión a factura digital',
         subscribeBody: 'Ingrese el email en el cual quiere recibir su factura',
         unsubscribeBody: 'Usted está a punto de deshaderirse de factura digital',
-        unsubscribeTitle: 'Baja de factura digital'
+        unsubscribeTitle: 'Baja de factura digital',
+        validation: 'Email invalido'
       }
     }
   }

--- a/src/redux/accounts/actions.js
+++ b/src/redux/accounts/actions.js
@@ -2,52 +2,11 @@ import { createTypes, completeTypes } from 'redux-recompose';
 
 import AccountService from 'services/AccountService';
 
-export const actions = createTypes(
-  completeTypes(
-    [
-      'GET_ACCOUNTS',
-      'DIGITAL_BILLING_UPDATE',
-      'DIGITAL_BILLING_SUBSCRIPTION',
-      'DIGITAL_BILLING_UNSUBSCRIPTION'
-    ],
-    ['SET_CURRENT_ACCOUNT']
-  ),
-  '@@ACCOUNTS'
-);
+export const actions = createTypes(completeTypes(['GET_ACCOUNTS'], ['SET_CURRENT_ACCOUNT']), '@@ACCOUNTS');
 
 const privateActionCreators = {
   getAccountsSuccess: payload => ({ type: actions.GET_ACCOUNTS_SUCCESS, payload, target: 'accounts' }),
-  getAccountsFailure: payload => ({ type: actions.GET_ACCOUNTS_FAILURE, payload, target: 'accounts' }),
-  digitalBillingUpdateSuccess: payload => ({
-    type: actions.DIGITAL_BILLING_UPDATE_SUCCESS,
-    payload,
-    target: 'accounts'
-  }),
-  digitalBillingUpdateFailure: payload => ({
-    type: actions.DIGITAL_BILLING_UPDATE_FAILURE,
-    payload,
-    target: 'accounts'
-  }),
-  digitalBillingSubscriptionSuccess: payload => ({
-    type: actions.DIGITAL_BILLING_SUBSCRIPTION_SUCCESS,
-    payload,
-    target: 'accounts'
-  }),
-  digitalBillingSubscriptionFailure: payload => ({
-    type: actions.DIGITAL_BILLING_SUBSCRIPTION_FAILURE,
-    payload,
-    target: 'accounts'
-  }),
-  digitalBillingUnsubscriptionSuccess: payload => ({
-    type: actions.DIGITAL_BILLING_UNSUBSCRIPTION_SUCCESS,
-    payload,
-    target: 'accounts'
-  }),
-  digitalBillingUnsubscriptionFailure: payload => ({
-    type: actions.DIGITAL_BILLING_UNSUBSCRIPTION_FAILURE,
-    payload,
-    target: 'accounts'
-  })
+  getAccountsFailure: payload => ({ type: actions.GET_ACCOUNTS_FAILURE, payload, target: 'accounts' })
 };
 
 export const actionCreators = {
@@ -60,56 +19,6 @@ export const actionCreators = {
       dispatch(privateActionCreators.getAccountsSuccess(response.data));
     } else {
       dispatch(privateActionCreators.getAccountsFailure(response.data.error));
-    }
-  },
-  digitalBillingUpdate: (email, profile) => async dispatch => {
-    dispatch({ type: actions.DIGITAL_BILLING_UPDATE, target: 'digitalBilling' });
-    const response = await AccountService.digitalBillingUpdate(email);
-    if (response.ok) {
-      const accounts = await AccountService.getAccounts();
-      const newCurrent = accounts.data.filter(account => account.perfil === profile)[0];
-      const updatedCurrent = {
-        ...newCurrent,
-        contact_emails: [...newCurrent.contact_emails, email]
-      };
-      await dispatch(actionCreators.setCurrentAccount(updatedCurrent));
-      dispatch(privateActionCreators.digitalBillingUpdateSuccess(accounts.data));
-    } else {
-      dispatch(privateActionCreators.digitalBillingUpdateFailure(response.data.error));
-    }
-  },
-  digitalBillingUnsubscription: (email, profile) => async dispatch => {
-    dispatch({ type: actions.DIGITAL_BILLING_UNSUBSCRIPTION, target: 'accountsZ' });
-    const response = await AccountService.digitalBillingUnsubscription(email);
-    if (response.ok) {
-      const accounts = await AccountService.getAccounts();
-      const newCurrent = accounts.data.filter(account => account.perfil === profile)[0];
-      const updatedCurrent = {
-        ...newCurrent,
-        adherido_factura_digital: false,
-        contact_emails: []
-      };
-      await dispatch(actionCreators.setCurrentAccount(updatedCurrent));
-      dispatch(privateActionCreators.digitalBillingUnsubscriptionSuccess(accounts.data));
-    } else {
-      dispatch(privateActionCreators.digitalBillingUnsubscriptionFailure(response.data.error));
-    }
-  },
-  digitalBillingSubscription: (email, profile) => async dispatch => {
-    dispatch({ type: actions.DIGITAL_BILLING_SUBSCRIPTION, target: 'accounts' });
-    const response = await AccountService.digitalBillingSubscription(email);
-    if (response.ok) {
-      const accounts = await AccountService.getAccounts();
-      const newCurrent = accounts.data.filter(account => account.perfil === profile)[0];
-      const updatedCurrent = {
-        ...newCurrent,
-        adherido_factura_digital: true,
-        contact_emails: [email]
-      };
-      await dispatch(actionCreators.setCurrentAccount(updatedCurrent));
-      dispatch(privateActionCreators.digitalBillingSubscriptionSuccess(accounts.data));
-    } else {
-      dispatch(privateActionCreators.digitalBillingSubscriptionFailure(response.data.error));
     }
   }
 };

--- a/src/redux/accounts/actions.js
+++ b/src/redux/accounts/actions.js
@@ -2,11 +2,52 @@ import { createTypes, completeTypes } from 'redux-recompose';
 
 import AccountService from 'services/AccountService';
 
-export const actions = createTypes(completeTypes(['GET_ACCOUNTS'], ['SET_CURRENT_ACCOUNT']), '@@ACCOUNTS');
+export const actions = createTypes(
+  completeTypes(
+    [
+      'GET_ACCOUNTS',
+      'DIGITAL_BILLING_UPDATE',
+      'DIGITAL_BILLING_SUBSCRIPTION',
+      'DIGITAL_BILLING_UNSUBSCRIPTION'
+    ],
+    ['SET_CURRENT_ACCOUNT']
+  ),
+  '@@ACCOUNTS'
+);
 
 const privateActionCreators = {
   getAccountsSuccess: payload => ({ type: actions.GET_ACCOUNTS_SUCCESS, payload, target: 'accounts' }),
-  getAccountsFailure: payload => ({ type: actions.GET_ACCOUNTS_FAILURE, payload, target: 'accounts' })
+  getAccountsFailure: payload => ({ type: actions.GET_ACCOUNTS_FAILURE, payload, target: 'accounts' }),
+  digitalBillingUpdateSuccess: payload => ({
+    type: actions.DIGITAL_BILLING_UPDATE_SUCCESS,
+    payload,
+    target: 'accounts'
+  }),
+  digitalBillingUpdateFailure: payload => ({
+    type: actions.DIGITAL_BILLING_UPDATE_FAILURE,
+    payload,
+    target: 'accounts'
+  }),
+  digitalBillingSubscriptionSuccess: payload => ({
+    type: actions.DIGITAL_BILLING_SUBSCRIPTION_SUCCESS,
+    payload,
+    target: 'accounts'
+  }),
+  digitalBillingSubscriptionFailure: payload => ({
+    type: actions.DIGITAL_BILLING_SUBSCRIPTION_FAILURE,
+    payload,
+    target: 'accounts'
+  }),
+  digitalBillingUnsubscriptionSuccess: payload => ({
+    type: actions.DIGITAL_BILLING_UNSUBSCRIPTION_SUCCESS,
+    payload,
+    target: 'accounts'
+  }),
+  digitalBillingUnsubscriptionFailure: payload => ({
+    type: actions.DIGITAL_BILLING_UNSUBSCRIPTION_FAILURE,
+    payload,
+    target: 'accounts'
+  })
 };
 
 export const actionCreators = {
@@ -19,6 +60,56 @@ export const actionCreators = {
       dispatch(privateActionCreators.getAccountsSuccess(response.data));
     } else {
       dispatch(privateActionCreators.getAccountsFailure(response.data.error));
+    }
+  },
+  digitalBillingUpdate: (email, profile) => async dispatch => {
+    dispatch({ type: actions.DIGITAL_BILLING_UPDATE, target: 'digitalBilling' });
+    const response = await AccountService.digitalBillingUpdate(email);
+    if (response.ok) {
+      const accounts = await AccountService.getAccounts();
+      const newCurrent = accounts.data.filter(account => account.perfil === profile)[0];
+      const updatedCurrent = {
+        ...newCurrent,
+        contact_emails: [...newCurrent.contact_emails, email]
+      };
+      await dispatch(actionCreators.setCurrentAccount(updatedCurrent));
+      dispatch(privateActionCreators.digitalBillingUpdateSuccess(accounts.data));
+    } else {
+      dispatch(privateActionCreators.digitalBillingUpdateFailure(response.data.error));
+    }
+  },
+  digitalBillingUnsubscription: (email, profile) => async dispatch => {
+    dispatch({ type: actions.DIGITAL_BILLING_UNSUBSCRIPTION, target: 'accountsZ' });
+    const response = await AccountService.digitalBillingUnsubscription(email);
+    if (response.ok) {
+      const accounts = await AccountService.getAccounts();
+      const newCurrent = accounts.data.filter(account => account.perfil === profile)[0];
+      const updatedCurrent = {
+        ...newCurrent,
+        adherido_factura_digital: false,
+        contact_emails: []
+      };
+      await dispatch(actionCreators.setCurrentAccount(updatedCurrent));
+      dispatch(privateActionCreators.digitalBillingUnsubscriptionSuccess(accounts.data));
+    } else {
+      dispatch(privateActionCreators.digitalBillingUnsubscriptionFailure(response.data.error));
+    }
+  },
+  digitalBillingSubscription: (email, profile) => async dispatch => {
+    dispatch({ type: actions.DIGITAL_BILLING_SUBSCRIPTION, target: 'accounts' });
+    const response = await AccountService.digitalBillingSubscription(email);
+    if (response.ok) {
+      const accounts = await AccountService.getAccounts();
+      const newCurrent = accounts.data.filter(account => account.perfil === profile)[0];
+      const updatedCurrent = {
+        ...newCurrent,
+        adherido_factura_digital: true,
+        contact_emails: [email]
+      };
+      await dispatch(actionCreators.setCurrentAccount(updatedCurrent));
+      dispatch(privateActionCreators.digitalBillingSubscriptionSuccess(accounts.data));
+    } else {
+      dispatch(privateActionCreators.digitalBillingSubscriptionFailure(response.data.error));
     }
   }
 };

--- a/src/redux/accounts/reducer.js
+++ b/src/redux/accounts/reducer.js
@@ -9,7 +9,7 @@ export const defaultState = {
 };
 
 const reducerDescription = {
-  primaryActions: [actions.GET_ACCOUNTS, actions.DIGITAL_BILLING_UPDATE],
+  primaryActions: [actions.GET_ACCOUNTS],
   override: {
     [actions.SET_CURRENT_ACCOUNT]: (state, action) =>
       Immutable.merge(state, { currentAccount: action.payload })

--- a/src/redux/accounts/reducer.js
+++ b/src/redux/accounts/reducer.js
@@ -9,7 +9,7 @@ export const defaultState = {
 };
 
 const reducerDescription = {
-  primaryActions: [actions.GET_ACCOUNTS],
+  primaryActions: [actions.GET_ACCOUNTS, actions.DIGITAL_BILLING_UPDATE],
   override: {
     [actions.SET_CURRENT_ACCOUNT]: (state, action) =>
       Immutable.merge(state, { currentAccount: action.payload })

--- a/src/redux/bills/actions.js
+++ b/src/redux/bills/actions.js
@@ -2,13 +2,55 @@ import { createTypes, completeTypes } from 'redux-recompose';
 
 import BillsService from 'services/billsService';
 
-export const actions = createTypes(completeTypes(['GET_BILLS', 'GET_LAST_BILL'], []), '@@BILLS');
+export const actions = createTypes(
+  completeTypes(
+    [
+      'GET_BILLS',
+      'GET_LAST_BILL',
+      'UPDATE_DIGITAL_BILLING',
+      'SUBSCRIBE_DIGITAL_BILLING',
+      'UNSUBSCRIBE_DIGITAL_BILLING'
+    ],
+    ['SET_DIGITAL_BILLING']
+  ),
+  '@@BILLS'
+);
 
 const privateActionCreators = {
   getBillsSuccess: payload => ({ type: actions.GET_BILLS_SUCCESS, payload, target: 'billsHistory' }),
   getBillsFailure: payload => ({ type: actions.GET_BILLS_FAILURE, payload, target: 'billsHistory' }),
   getLastBillSuccess: payload => ({ type: actions.GET_LAST_BILL_SUCCESS, payload, target: 'lastBill' }),
-  getLastBillFailure: payload => ({ type: actions.GET_LAST_BILL_FAILURE, payload, target: 'lastBill' })
+  getLastBillFailure: payload => ({ type: actions.GET_LAST_BILL_FAILURE, payload, target: 'lastBill' }),
+  digitalBillingUpdateSuccess: payload => ({
+    type: actions.UPDATE_DIGITAL_BILLING_SUCCESS,
+    payload,
+    target: 'digitalBilling'
+  }),
+  digitalBillingUpdateFailure: payload => ({
+    type: actions.UPDATE_DIGITAL_BILLING_FAILURE,
+    payload,
+    target: 'digitalBilling'
+  }),
+  digitalBillingSubscriptionSuccess: payload => ({
+    type: actions.SUBSCRIBE_DIGITAL_BILLING_SUCCESS,
+    payload,
+    target: 'digitalBilling'
+  }),
+  digitalBillingSubscriptionFailure: payload => ({
+    type: actions.SUBSCRIBE_DIGITAL_BILLING_FAILURE,
+    payload,
+    target: 'digitalBilling'
+  }),
+  digitalBillingUnsubscriptionSuccess: payload => ({
+    type: actions.UNSUBSCRIBE_DIGITAL_BILLING_SUCCESS,
+    payload,
+    target: 'digitalBilling'
+  }),
+  digitalBillingUnsubscriptionFailure: payload => ({
+    type: actions.UNSUBSCRIBE_DIGITAL_BILLING_FAILURE,
+    payload,
+    target: 'digitalBilling'
+  })
 };
 
 export const actionCreators = {
@@ -28,6 +70,50 @@ export const actionCreators = {
       dispatch(privateActionCreators.getLastBillSuccess(response.data[0]));
     } else {
       dispatch(privateActionCreators.getLastBillFailure(response.data.error));
+    }
+  },
+  setDigitalBilling: billingData => dispatch =>
+    dispatch({ type: actions.SET_DIGITAL_BILLING, payload: billingData }),
+  digitalBillingUpdate: email => async (dispatch, getState) => {
+    dispatch({ type: actions.UPDATE_DIGITAL_BILLING, target: 'digitalBilling' });
+    const response = await BillsService.digitalBillingUpdate(email);
+    if (response.ok) {
+      dispatch(
+        privateActionCreators.digitalBillingUpdateSuccess({
+          ...getState().bills.digitalBilling,
+          contact_emails: [email]
+        })
+      );
+    } else {
+      dispatch(privateActionCreators.digitalBillingUpdateFailure(response.data.error));
+    }
+  },
+  digitalBillingUnsubscription: email => async dispatch => {
+    dispatch({ type: actions.UNSUBSCRIBE_DIGITAL_BILLING, target: 'digitalBilling' });
+    const response = await BillsService.digitalBillingUnsubscription(email);
+    if (response.ok) {
+      dispatch(
+        privateActionCreators.digitalBillingUnsubscriptionSuccess({
+          adherido_factura_digital: false,
+          contact_emails: []
+        })
+      );
+    } else {
+      dispatch(privateActionCreators.digitalBillingUnsubscriptionFailure(response.data.error));
+    }
+  },
+  digitalBillingSubscription: email => async dispatch => {
+    dispatch({ type: actions.SUBSCRIBE_DIGITAL_BILLING, target: 'digitalBilling' });
+    const response = await BillsService.digitalBillingSubscription(email);
+    if (response.ok) {
+      dispatch(
+        privateActionCreators.digitalBillingSubscriptionSuccess({
+          adherido_factura_digital: true,
+          contact_emails: [email]
+        })
+      );
+    } else {
+      dispatch(privateActionCreators.digitalBillingSubscriptionFailure(response.data.error));
     }
   }
 };

--- a/src/redux/bills/reducer.js
+++ b/src/redux/bills/reducer.js
@@ -6,12 +6,22 @@ import { actions } from './actions';
 export const defaultState = {
   billsHistory: [],
   billsHistoryLoading: false,
+  digitalBilling: {},
   lastBill: {}
 };
 
 const reducerDescription = {
-  primaryActions: [actions.GET_BILLS, actions.GET_LAST_BILL],
-  override: {}
+  primaryActions: [
+    actions.GET_BILLS,
+    actions.GET_LAST_BILL,
+    actions.UPDATE_DIGITAL_BILLING,
+    actions.SUBSCRIBE_DIGITAL_BILLING,
+    actions.UNSUBSCRIBE_DIGITAL_BILLING
+  ],
+  override: {
+    [actions.SET_DIGITAL_BILLING]: (state, action) =>
+      Immutable.merge(state, { digitalBilling: action.payload })
+  }
 };
 
 export const reducer = createReducer(Immutable(defaultState), completeReducer(reducerDescription));

--- a/src/services/AccountService.js
+++ b/src/services/AccountService.js
@@ -1,5 +1,8 @@
 import api from 'config/api';
 
 export default {
-  getAccounts: () => api.get('cuentas_asociadas')
+  getAccounts: () => api.get('cuentas_asociadas'),
+  digitalBillingUpdate: email => api.put('factura_digital', email),
+  digitalBillingSubscription: email => api.post('factura_digital', email),
+  digitalBillingUnsubscription: email => api.delete('factura_digital', email)
 };

--- a/src/services/billsService.js
+++ b/src/services/billsService.js
@@ -2,5 +2,8 @@ import api from 'config/api';
 
 export default {
   getBills: () => api.get('listado_de_facturas'),
-  getLastBill: () => api.get('ultima_factura')
+  getLastBill: () => api.get('ultima_factura'),
+  digitalBillingUpdate: email => api.put('factura_digital', email),
+  digitalBillingSubscription: email => api.post('factura_digital', email),
+  digitalBillingUnsubscription: email => api.delete('factura_digital', email)
 };

--- a/src/types/accountTypes.js
+++ b/src/types/accountTypes.js
@@ -1,4 +1,4 @@
-import { shape, string, bool } from 'prop-types';
+import { shape, string, bool, array, number } from 'prop-types';
 
 export const accountType = shape({
   cuenta_id: string,
@@ -12,5 +12,6 @@ export const accountType = shape({
   partido: string,
   alias: string,
   relacion: string,
-  perfil: 1
+  perfil: number,
+  contact_emails: array
 });

--- a/src/types/digitalBillingTypes.js
+++ b/src/types/digitalBillingTypes.js
@@ -1,0 +1,6 @@
+import { shape, bool, array } from 'prop-types';
+
+export const digitalBillingType = shape({
+  adherido_factura_digital: bool,
+  contact_emails: array
+});

--- a/src/types/modalTypes.js
+++ b/src/types/modalTypes.js
@@ -1,0 +1,8 @@
+import { shape, string, bool, func } from 'prop-types';
+
+export const modalTypes = shape({
+  showModal: bool,
+  cancelText: string,
+  ctaText: string,
+  handleCta: func
+});

--- a/src/types/tagTypes.js
+++ b/src/types/tagTypes.js
@@ -1,0 +1,6 @@
+import { shape, string } from 'prop-types';
+
+export const tagTypes = shape({
+  text: string,
+  status: string
+});


### PR DESCRIPTION
## Summary

- Card para mostrar detalle de factura digital
- Modal genérico para ABM factura digital
- Estados para ese modal dependiendo del trámite
- Acciones, reducer y service para ABM

## Test Cases

La card de factura digital debería cambiar según si el cliente está o no adherido. Los distintos botones dentro de la card deberían abrir distintos estados del modal. Los estados del modal que usen input no deberían permitir continuar si el texto ingresado es inválido. El botón de cancel debería cerrar el botón. Se debería poder realizar el ABM sin problemas. Todo debería ajustarse a distintos tamaños de pantalla. Iniciar el proyecto en segba debería ser posible, pero no se debería mostrar nada del nuevo feat.

## Screenshots

![image](https://github.com/facu-rodriguez/New-training-test/assets/72291544/aed8ee4c-0a94-40c5-9b5e-f3531fbe3c44)
![image](https://github.com/facu-rodriguez/New-training-test/assets/72291544/8f090056-9b4d-4969-b946-c57cb464529f)
![image](https://github.com/facu-rodriguez/New-training-test/assets/72291544/252e3a62-37d1-40b5-b846-0941a5a94bb4)
![image](https://github.com/facu-rodriguez/New-training-test/assets/72291544/0ac97780-e850-45a1-8ba5-fa5e9ed4dc72)
![image](https://github.com/facu-rodriguez/New-training-test/assets/72291544/d14d0a2e-529c-4f4a-8fd5-3c4fa3e269b5)
![image](https://github.com/facu-rodriguez/New-training-test/assets/72291544/8fac0d96-d543-45b7-8a4e-fa361da561e9)
![image](https://github.com/facu-rodriguez/New-training-test/assets/72291544/788ef821-9bb7-4d10-b15e-9068dfa8968e)
